### PR TITLE
feat: ScalarFieldToObjectFieldRewriter

### DIFF
--- a/src/RewriteHandler.ts
+++ b/src/RewriteHandler.ts
@@ -1,10 +1,10 @@
-import { parse, print } from 'graphql';
-import { extractPath, rewriteDoc, rewriteResultsAtPath } from './ast';
+import { parse, print, FragmentDefinitionNode } from 'graphql';
+import { extractPath, FragmentTracer, rewriteDoc, rewriteResultsAtPath } from './ast';
 import Rewriter, { Variables } from './rewriters/Rewriter';
 
 interface RewriterMatch {
   rewriter: Rewriter;
-  path: ReadonlyArray<string>;
+  paths: ReadonlyArray<ReadonlyArray<string>>;
 }
 
 /**
@@ -30,6 +30,7 @@ export default class RewriteHandler {
     if (this.hasProcessedRequest) throw new Error('This handler has already rewritten a request');
     this.hasProcessedRequest = true;
     const doc = parse(query);
+    const fragmentTracer = new FragmentTracer(doc);
     let rewrittenVariables = variables;
     const rewrittenDoc = rewriteDoc(doc, (nodeAndVars, parents) => {
       let rewrittenNodeAndVars = nodeAndVars;
@@ -38,9 +39,17 @@ export default class RewriteHandler {
         if (isMatch) {
           rewrittenVariables = rewriter.rewriteVariables(rewrittenNodeAndVars, rewrittenVariables);
           rewrittenNodeAndVars = rewriter.rewriteQuery(rewrittenNodeAndVars);
+          const simplePath = extractPath([...parents, rewrittenNodeAndVars.node]);
+          let paths: ReadonlyArray<ReadonlyArray<string>> = [simplePath];
+          const fragmentDef = parents.find(({ kind }) => kind === 'FragmentDefinition') as
+            | FragmentDefinitionNode
+            | undefined;
+          if (fragmentDef) {
+            paths = fragmentTracer.prependFragmentPaths(fragmentDef.name.value, simplePath);
+          }
           this.matches.push({
             rewriter,
-            path: extractPath([...parents, rewrittenNodeAndVars.node])
+            paths
           });
         }
         return isMatch;
@@ -60,10 +69,12 @@ export default class RewriteHandler {
     if (this.hasProcessedResponse) throw new Error('This handler has already returned a response');
     this.hasProcessedResponse = true;
     let rewrittenResponse = response;
-    this.matches.reverse().forEach(({ rewriter, path }) => {
-      rewrittenResponse = rewriteResultsAtPath(rewrittenResponse, path, responseAtPath =>
-        rewriter.rewriteResponse(responseAtPath)
-      );
+    this.matches.reverse().forEach(({ rewriter, paths }) => {
+      paths.forEach(path => {
+        rewrittenResponse = rewriteResultsAtPath(rewrittenResponse, path, responseAtPath =>
+          rewriter.rewriteResponse(responseAtPath)
+        );
+      });
     });
     return rewrittenResponse;
   }

--- a/src/RewriteHandler.ts
+++ b/src/RewriteHandler.ts
@@ -1,4 +1,4 @@
-import { parse, print, FragmentDefinitionNode } from 'graphql';
+import { FragmentDefinitionNode, parse, print } from 'graphql';
 import { extractPath, FragmentTracer, rewriteDoc, rewriteResultsAtPath } from './ast';
 import Rewriter, { Variables } from './rewriters/Rewriter';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,6 @@ export { default as FieldArgNameRewriter } from './rewriters/FieldArgNameRewrite
 export { default as FieldArgsToInputTypeRewriter } from './rewriters/FieldArgsToInputTypeRewriter';
 export { default as FieldArgTypeRewriter } from './rewriters/FieldArgTypeRewriter';
 export { default as NestFieldOutputsRewriter } from './rewriters/NestFieldOutputsRewriter';
+export {
+  default as ScalarFieldToObjectFieldRewriter
+} from './rewriters/ScalarFieldToObjectFieldRewriter';

--- a/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
+++ b/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
@@ -1,0 +1,60 @@
+import { ASTNode, FieldNode, SelectionSetNode } from 'graphql';
+import { NodeAndVarDefs } from '../ast';
+import Rewriter, { RewriterOpts } from './Rewriter';
+
+interface ScalarFieldToObjectFieldRewriterOpts extends RewriterOpts {
+  objectFieldName: string;
+}
+
+/**
+ * Rewriter which nests output fields inside of a new output object
+ * ex: change from `field { subField }` to `field { subField { objectfield } }`
+ */
+class ScalarFieldToObjectFieldRewriter extends Rewriter {
+  protected objectFieldName: string;
+
+  constructor(options: ScalarFieldToObjectFieldRewriterOpts) {
+    super(options);
+    this.objectFieldName = options.objectFieldName;
+  }
+
+  public matches(nodeAndVars: NodeAndVarDefs, parents: ASTNode[]): boolean {
+    if (!super.matches(nodeAndVars, parents)) return false;
+    const node = nodeAndVars.node as FieldNode;
+    // make sure there's no subselections on this field
+    if (node.selectionSet) return false;
+    return true;
+  }
+
+  public rewriteQuery(nodeAndVarDefs: NodeAndVarDefs) {
+    const node = nodeAndVarDefs.node as FieldNode;
+    const { variableDefinitions } = nodeAndVarDefs;
+    // if there's a subselection already, just return
+    if (node.selectionSet) return nodeAndVarDefs;
+
+    const selectionSet: SelectionSetNode = {
+      kind: 'SelectionSet',
+      selections: [
+        {
+          kind: 'Field',
+          name: { kind: 'Name', value: this.objectFieldName }
+        }
+      ]
+    };
+
+    return {
+      variableDefinitions,
+      node: { ...node, selectionSet }
+    } as NodeAndVarDefs;
+  }
+
+  public rewriteResponse(response: any) {
+    if (typeof response === 'object') {
+      // undo the nesting in the response so it matches the original query
+      return response[this.objectFieldName];
+    }
+    return response;
+  }
+}
+
+export default ScalarFieldToObjectFieldRewriter;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,2 +1,8 @@
 /** @hidden */
 export const identifyFunc = <T>(val: T) => val;
+
+/** @hidden */
+export const pushToArrayAtKey = <T>(mapping: { [key: string]: T[] }, key: string, val: T): void => {
+  if (!mapping[key]) mapping[key] = [];
+  mapping[key].push(val);
+};

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -4,7 +4,8 @@ import {
   extractVariableDefinitions,
   nodesMatch,
   replaceVariableDefinitions,
-  rewriteResultsAtPath
+  rewriteResultsAtPath,
+  FragmentTracer
 } from '../src/ast';
 
 describe('ast utils', () => {
@@ -210,30 +211,80 @@ describe('ast utils', () => {
       ];
       expect(extractPath(parents)).toEqual(['thing1', 'thing2', 'thing3', 'thing4']);
     });
+  });
 
-    it('reconstructs the path through fragments', () => {
+  describe('FragmentTracer', () => {
+    it('derives all nested paths to each fragment in the document', () => {
       const doc = parse(`
         query doStuff($arg1: String) {
           thing1 {
             thing2 {
-              ... thing2Fragment
+              ... fragment1
             }
+            ... fragment1
+          }
+          ... fragment2
+        }
+
+        fragment fragment1 on Thing {
+          thing3 {
+            ... fragment2
+          }
+          ... fragment2
+        }
+
+        fragment fragment2 on Thing {
+          thing4
+        }
+      `);
+      const tracer = new FragmentTracer(doc);
+      expect(tracer.getPathsToFragment('fragment1')).toEqual([['thing1', 'thing2'], ['thing1']]);
+      expect(tracer.getPathsToFragment('fragment2')).toEqual([
+        [],
+        ['thing1', 'thing2', 'thing3'],
+        ['thing1', 'thing2'],
+        ['thing1', 'thing3'],
+        ['thing1']
+      ]);
+    });
+
+    it('return empty array if there are no paths to the fragment', () => {
+      const doc = parse(`
+        query doStuff($arg1: String) {
+          thing1 {
+            name
+          }
+        }
+        fragment fragment2 on Thing {
+          meh
+        }
+      `);
+      const tracer = new FragmentTracer(doc);
+      expect(tracer.getPathsToFragment('fragment2')).toEqual([]);
+      expect(tracer.getPathsToFragment('nonExistentFragment')).toEqual([]);
+    });
+
+    it('does not get stuck in infinite loops in fragments', () => {
+      const doc = parse(`
+        query doStuff($arg1: String) {
+          ... fragment1
+        }
+
+        fragment fragment1 on Thing {
+          thing1 {
+            ...fragment2
           }
         }
 
-        fragment thing2Fragment on Thing2 {
-          thing3
+        fragment fragment2 on Thing {
+          thing2 {
+            ...fragment1
+          }
         }
       `);
-      const parents = [
-        doc as any,
-        (doc as any).definitions[1],
-        (doc as any).definitions[1].selectionSet,
-        (doc as any).definitions[1].selectionSet.selections[0]
-      ];
-
-      debugger;
-      expect(extractPath(parents)).toEqual(['thing1', 'thing2', 'thing3']);
+      const tracer = new FragmentTracer(doc);
+      expect(tracer.getPathsToFragment('fragment1')).toEqual([[], ['thing1', 'thing2']]);
+      expect(tracer.getPathsToFragment('fragment2')).toEqual([['thing1']]);
     });
   });
 });

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -210,5 +210,30 @@ describe('ast utils', () => {
       ];
       expect(extractPath(parents)).toEqual(['thing1', 'thing2', 'thing3', 'thing4']);
     });
+
+    it('reconstructs the path through fragments', () => {
+      const doc = parse(`
+        query doStuff($arg1: String) {
+          thing1 {
+            thing2 {
+              ... thing2Fragment
+            }
+          }
+        }
+
+        fragment thing2Fragment on Thing2 {
+          thing3
+        }
+      `);
+      const parents = [
+        doc as any,
+        (doc as any).definitions[1],
+        (doc as any).definitions[1].selectionSet,
+        (doc as any).definitions[1].selectionSet.selections[0]
+      ];
+
+      debugger;
+      expect(extractPath(parents)).toEqual(['thing1', 'thing2', 'thing3']);
+    });
   });
 });

--- a/test/functional/rewriteScalarFieldToObjectField.test.ts
+++ b/test/functional/rewriteScalarFieldToObjectField.test.ts
@@ -1,0 +1,117 @@
+import RewriteHandler from '../../src/RewriteHandler';
+import ScalarFieldToObjectFieldRewriter from '../../src/rewriters/ScalarFieldToObjectFieldRewriter';
+import { gqlFmt } from '../testUtils';
+
+describe('Rewrite scalar field to be a nested object with a single scalar field', () => {
+  it('rewrites a scalar field to be an objet field with 1 scalar subfield', () => {
+    const handler = new RewriteHandler([
+      new ScalarFieldToObjectFieldRewriter({
+        fieldName: 'title',
+        objectFieldName: 'text'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            title
+            color
+          }
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            title {
+              text
+            }
+            color
+          }
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          thingField: {
+            id: 1,
+            title: {
+              text: 'THING'
+            },
+            color: 'blue'
+          }
+        }
+      })
+    ).toEqual({
+      theThing: {
+        thingField: {
+          id: 1,
+          title: 'THING',
+          color: 'blue'
+        }
+      }
+    });
+  });
+
+  it('works with fragments', () => {
+    const handler = new RewriteHandler([
+      new ScalarFieldToObjectFieldRewriter({
+        fieldName: 'title',
+        objectFieldName: 'text'
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        title
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        title {
+          text
+        }
+      }
+    `;
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+    expect(
+      handler.rewriteResponse({
+        theThing: {
+          id: 1,
+          title: {
+            text: 'THING'
+          }
+        }
+      })
+    ).toEqual({
+      theThing: {
+        id: 1,
+        title: 'THING'
+      }
+    });
+  });
+});

--- a/tslint.json
+++ b/tslint.json
@@ -3,6 +3,7 @@
   "rules": {
     "interface-name": false,
     "object-literal-sort-keys": false,
-    "no-increment-decrement": false
+    "no-increment-decrement": false,
+    "prefer-array-literal": [true, { "allow-type-parameters": true }]
   }
 }


### PR DESCRIPTION
This PR adds a new rewriter type called `ScalarFieldToObjectFieldRewriter`. This rewriter allows rewriting a field that's a scalar, like `title: 'blah'`, to an object with a single nested scalar, like `{ title:  { text: 'blah' } }`.

For example, this would allow transitioning from a schema like:

```graphql
type Article {
  title: String!
  ...
}
```

to

```graphql
type ArticleTitle {
  text: String!
  localizedText: string
}

type Article {
  title: ArticleTitle!
 ...
}
```

The rewriter to do this would look like:

```js
new ScalarFieldToObjectFieldRewriter({
    fieldName: 'title',
    objectFieldName: 'text'
})
```

Then, when an old query arrives requesting: 

```graphql
query {
  article(id: 123) {
    title
  }
}
```

this will be rewritten to

```graphql
query {
  article(id: 123) {
    title {
      text
    }
  }
}
```