### PR TITLE
Adding new rewriter to convert GraphQLJSON type field query into typed object query

### DIFF
--- a/src/rewriters/JsonToTypedObjectRewriter.ts
+++ b/src/rewriters/JsonToTypedObjectRewriter.ts
@@ -1,0 +1,56 @@
+import { ASTNode, FieldNode, SelectionSetNode } from 'graphql';
+import { NodeAndVarDefs } from '../ast';
+import Rewriter, { RewriterOpts } from './Rewriter';
+
+interface ObjectField {
+  name: string;
+  subFields?: ObjectField[];
+}
+
+interface JsonToTypedObjectRewriterOpts extends RewriterOpts {
+  objectFields: ObjectField[];
+}
+
+export default class JsonToTypedObjectRewriter extends Rewriter {
+  protected objectFields: ObjectField[];
+
+  constructor({ fieldName, objectFields }: JsonToTypedObjectRewriterOpts) {
+    super({ fieldName });
+    this.objectFields = objectFields;
+  }
+
+  public matches(nodeAndVars: NodeAndVarDefs, parents: ASTNode[]): boolean {
+    if (!super.matches(nodeAndVars, parents)) return false;
+    const node = nodeAndVars.node as FieldNode;
+    // make sure there's no subselections on this field
+    if (node.selectionSet) return false;
+    return true;
+  }
+
+  public rewriteQuery(nodeAndVarDefs: NodeAndVarDefs): NodeAndVarDefs {
+    const node = nodeAndVarDefs.node as FieldNode;
+    const { variableDefinitions } = nodeAndVarDefs;
+    // if there's a subselection already, just return
+    if (node.selectionSet) return nodeAndVarDefs;
+
+    const selectionSet = this.generateSelectionSet(this.objectFields);
+
+    return {
+      variableDefinitions,
+      node: { ...node, selectionSet }
+    } as NodeAndVarDefs;
+  }
+
+  private generateSelectionSet(fields: ObjectField[]): SelectionSetNode {
+    return {
+      kind: 'SelectionSet',
+      selections: fields.map(({ name, subFields }) => ({
+        kind: 'Field',
+        name: { kind: 'Name', value: name },
+        ...(subFields && {
+          selectionSet: this.generateSelectionSet(subFields)
+        })
+      }))
+    } as SelectionSetNode;
+  }
+}

--- a/src/rewriters/index.ts
+++ b/src/rewriters/index.ts
@@ -4,3 +4,4 @@ export { default as FieldArgsToInputTypeRewriter } from './FieldArgsToInputTypeR
 export { default as FieldArgTypeRewriter } from './FieldArgTypeRewriter';
 export { default as NestFieldOutputsRewriter } from './NestFieldOutputsRewriter';
 export { default as ScalarFieldToObjectFieldRewriter } from './ScalarFieldToObjectFieldRewriter';
+export { default as JsonToTypedObjectRewriter } from './JsonToTypedObjectRewriter';

--- a/test/functional/rewriteJsonToTypedObjectRewriter.test.ts
+++ b/test/functional/rewriteJsonToTypedObjectRewriter.test.ts
@@ -1,0 +1,223 @@
+import RewriteHandler from '../../src/RewriteHandler';
+import JsonToTypedObjectRewriter from '../../src/rewriters/JsonToTypedObjectRewriter';
+import { gqlFmt } from '../testUtils';
+
+describe('Rewrite query for GraphQLJSON field to be a query for a nested object with multiple scalar and/or object types', () => {
+  it('rewrites a GraphQLJSON field query to be an object field query with multiple scalar subfields', () => {
+    const handler = new RewriteHandler([
+      new JsonToTypedObjectRewriter({
+        fieldName: 'thingJSON',
+        objectFields: [{ name: 'title' }, { name: 'description' }]
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            thingJSON
+            color
+          }
+        }
+      }
+    `;
+    const expectedRewrittenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            thingJSON {
+              title
+              description
+            }
+            color
+          }
+        }
+      }
+    `;
+
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewrittenQuery
+    });
+  });
+
+  it('rewrites a GraphQLJSON field query to be an object field query with multiple nested object types and subfields', () => {
+    const handler = new RewriteHandler([
+      new JsonToTypedObjectRewriter({
+        fieldName: 'thingJSON',
+        objectFields: [
+          {
+            name: 'user',
+            subFields: [
+              { name: 'userId' },
+              { name: 'userHandle' },
+              {
+                name: 'item',
+                subFields: [{ name: 'itemMeta' }]
+              }
+            ]
+          }
+        ]
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            thingJSON
+            color
+          }
+        }
+      }
+    `;
+    const expectedRewrittenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          thingField {
+            id
+            thingJSON {
+              user {
+                userId
+                userHandle
+                item {
+                  itemMeta
+                }
+              }
+            }
+            color
+          }
+        }
+      }
+    `;
+
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewrittenQuery
+    });
+  });
+
+  it('works with fragments', () => {
+    const handler = new RewriteHandler([
+      new JsonToTypedObjectRewriter({
+        fieldName: 'thingJSON',
+        objectFields: [{ name: 'title' }, { name: 'description' }]
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        thingJSON
+      }
+    `;
+    const expectedRewrittenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        thingJSON {
+          title
+          description
+        }
+      }
+    `;
+
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewrittenQuery
+    });
+  });
+
+  it('works within repeated and nested fragments', () => {
+    const handler = new RewriteHandler([
+      new JsonToTypedObjectRewriter({
+        fieldName: 'thingJSON',
+        objectFields: [
+          {
+            name: 'user',
+            subFields: [
+              { name: 'userId' },
+              { name: 'userHandle' },
+              {
+                name: 'item',
+                subFields: [{ name: 'itemMeta' }]
+              }
+            ]
+          }
+        ]
+      })
+    ]);
+
+    const query = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+        otherThing {
+          ...otherThingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        thingJSON
+      }
+
+      fragment otherThingFragment on Thing {
+        id
+        edges {
+          node {
+            ...thingFragment
+          }
+        }
+      }
+    `;
+    const expectedRewritenQuery = gqlFmt`
+      query getTheThing {
+        theThing {
+          ...thingFragment
+        }
+        otherThing {
+          ...otherThingFragment
+        }
+      }
+
+      fragment thingFragment on Thing {
+        id
+        thingJSON {
+          user {
+            userId
+            userHandle
+            item {
+              itemMeta
+            }
+          }
+        }
+      }
+
+      fragment otherThingFragment on Thing {
+        id
+        edges {
+          node {
+            ...thingFragment
+          }
+        }
+      }
+    `;
+
+    expect(handler.rewriteRequest(query)).toEqual({
+      query: expectedRewritenQuery
+    });
+  });
+});


### PR DESCRIPTION
**In this PR:**

- Adding `JsonToTypedObjectRewriter` class which extends Rewriter class and borrows some logic from ScalarFieldToObjectFieldRewriter
- Exporting `JsonToTypedObjectRewriter` class
- Adding `JsonToTypedObjectRewriter` tests

The purpose of `JsonToTypedObjectRewriter` is to deal with a situation in which the initial schema has a field of type `GraphQLJSON` ([graphql-type-json](https://github.com/taion/graphql-type-json)), but there is subsequent desire to type the `GraphQLJSON` blob field in order to strengthen the contract.

The issue is that updating the `GraphQLJSON` field to a typed object at the GraphQL layer will break the client-side query, since it doesn't specify subfields. `JsonToTypedObjectRewriter` aims to resolve that issue by rewriting the query at the service level but still returning the same response as initially expected by the client.

**Example:**

Initially we have a `user` field with type `GraphQLJSON`:

`user: { type:  GraphQLJSON }`

And it's queried for like this:

```
  query getTheThing {
    theThing {
      user
    }
  }
```

But then we want to type out the `user` field at the GraphQL layer:

`user: { type:  User }`

Where `User` has the following fields:

```
  userId: { type: GraphQLString },
  userHandle: { type: GraphQLString },
  isAdmin: { type: GraphQLBoolean }
  userMeta: { type: UserMeta }
```

Once we type this out, the client query will no longer be satisfactory since it's not requesting the `user` subfields, but we can resolve this via the `JsonToTypedObjectRewriter`:

```
graphqlRewriterMiddleware({
  rewriters: [
    new JsonToTypedObjectRewriter({
      fieldName: 'user',
      objectFields: [
        { name: 'userId' },
        { name: 'userHandle' },
        { name: 'isAdmin' },
        {
          name: 'userMeta',
          subFields: [
           { name: 'meta1' },
           { name: 'meta2' }
         ],
        }
      ]
    })
  ]
})
```

Which will rewrite out the query like so:

```
  query getTheThing {
    theThing {
      user {
        userId
        userHandle
        isAdmin
        userMeta {
          meta1
          meta2
        }
      }
    }
  }
```

This way, we can type out the JSON blob `user` field at the GraphQL layer and release the update without disrupting the client, and then subsequently update the client query at our discretion to request only the `user` subfields the client actually needs. 

**TODO**: Update the `README` if this is determined to be a feature worth adding. 