### PR TITLE
feat: make`matches` public on `RewriterHandler`

### DIFF
--- a/src/RewriteHandler.ts
+++ b/src/RewriteHandler.ts
@@ -12,8 +12,9 @@ interface RewriterMatch {
  * This class handles rewriting the query and the reponse according to the rewriters passed in
  */
 export default class RewriteHandler {
+  public matches: RewriterMatch[] = [];
+
   private rewriters: Rewriter[];
-  private matches: RewriterMatch[] = [];
   private hasProcessedRequest: boolean = false;
   private hasProcessedResponse: boolean = false;
 


### PR DESCRIPTION
closes #16

This PR makes `matches` a public field, so middleware can access it to determine if there's been matches / what has been matched. 