### PR TITLE
feat(rewriter): expose parent object and element path to rewriter

### DIFF
--- a/src/RewriteHandler.ts
+++ b/src/RewriteHandler.ts
@@ -72,10 +72,8 @@ export default class RewriteHandler {
     let rewrittenResponse = response;
     this.matches.reverse().forEach(({ rewriter, paths }) => {
       paths.forEach(path => {
-        rewrittenResponse = rewriteResultsAtPath(
-          rewrittenResponse,
-          path,
-          (parentResponse, childPath) => rewriter.rewriteResponse(parentResponse, childPath)
+        rewrittenResponse = rewriteResultsAtPath(rewrittenResponse, path, (parentResponse, key) =>
+          rewriter.rewriteResponse(parentResponse, key)
         );
       });
     });

--- a/src/RewriteHandler.ts
+++ b/src/RewriteHandler.ts
@@ -72,8 +72,10 @@ export default class RewriteHandler {
     let rewrittenResponse = response;
     this.matches.reverse().forEach(({ rewriter, paths }) => {
       paths.forEach(path => {
-        rewrittenResponse = rewriteResultsAtPath(rewrittenResponse, path, (parentResponse, path) =>
-          rewriter.rewriteResponse(parentResponse, path)
+        rewrittenResponse = rewriteResultsAtPath(
+          rewrittenResponse,
+          path,
+          (parentResponse, childPath) => rewriter.rewriteResponse(parentResponse, childPath)
         );
       });
     });

--- a/src/RewriteHandler.ts
+++ b/src/RewriteHandler.ts
@@ -72,8 +72,8 @@ export default class RewriteHandler {
     let rewrittenResponse = response;
     this.matches.reverse().forEach(({ rewriter, paths }) => {
       paths.forEach(path => {
-        rewrittenResponse = rewriteResultsAtPath(rewrittenResponse, path, responseAtPath =>
-          rewriter.rewriteResponse(responseAtPath)
+        rewrittenResponse = rewriteResultsAtPath(rewrittenResponse, path, (parentResponse, path) =>
+          rewriter.rewriteResponse(parentResponse, path)
         );
       });
     });

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -261,7 +261,7 @@ interface ResultObj {
 export const rewriteResultsAtPath = (
   results: ResultObj,
   path: ReadonlyArray<string>,
-  callback: (parentResult: any, path: string | number) => any
+  callback: (parentResult: any, key: string | number) => any
 ): ResultObj => {
   if (path.length === 0) return results;
 

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -261,24 +261,38 @@ interface ResultObj {
 export const rewriteResultsAtPath = (
   results: ResultObj,
   path: ReadonlyArray<string>,
-  callback: (resultsAtPath: any) => any
+  callback: (parentResult: any, path: string | number) => any
 ): ResultObj => {
-  if (path.length === 0) return callback(results);
+  if (path.length === 0) return results;
+
   const curPathElm = path[0];
-  const remainingPath = path.slice(1);
   const newResults = { ...results };
   const curResults = results[curPathElm];
+
+  if (path.length === 1) {
+    if (Array.isArray(curResults)) {
+      newResults[curPathElm] = curResults.map((_, index) => {
+        const newValue = callback(curResults, index);
+        return newValue;
+      });
+    } else {
+      newResults[curPathElm] = callback(results, curPathElm);
+    }
+
+    return newResults;
+  }
+
+  const remainingPath = path.slice(1);
   // if the path stops here, just return results without any rewriting
   if (curResults === undefined || curResults === null) return results;
 
   if (Array.isArray(curResults)) {
-    newResults[curPathElm] = curResults.reduce((acc, resultElm) => {
-      const elmResults = rewriteResultsAtPath(resultElm, remainingPath, callback);
-      return acc.concat(elmResults);
-    }, []);
-    return newResults;
+    newResults[curPathElm] = curResults.map(result =>
+      rewriteResultsAtPath(result, remainingPath, callback)
+    );
+  } else {
+    newResults[curPathElm] = rewriteResultsAtPath(curResults, remainingPath, callback);
   }
 
-  newResults[curPathElm] = rewriteResultsAtPath(curResults, remainingPath, callback);
   return newResults;
 };

--- a/src/rewriters/NestFieldOutputsRewriter.ts
+++ b/src/rewriters/NestFieldOutputsRewriter.ts
@@ -65,8 +65,8 @@ class NestFieldOutputsRewriter extends Rewriter {
     } as NodeAndVarDefs;
   }
 
-  public rewriteResponse(response: any, path: string) {
-    const pathResponse = super.rewriteResponse(response, path);
+  public rewriteResponse(response: any, key: string | number) {
+    const pathResponse = super.rewriteResponse(response, key);
 
     if (typeof pathResponse === 'object') {
       // undo the nesting in the response so it matches the original query

--- a/src/rewriters/NestFieldOutputsRewriter.ts
+++ b/src/rewriters/NestFieldOutputsRewriter.ts
@@ -65,16 +65,21 @@ class NestFieldOutputsRewriter extends Rewriter {
     } as NodeAndVarDefs;
   }
 
-  public rewriteResponse(response: any) {
-    if (typeof response === 'object') {
+  public rewriteResponse(response: any, path: string) {
+    const pathResponse = super.rewriteResponse(response, path);
+
+    if (typeof pathResponse === 'object') {
       // undo the nesting in the response so it matches the original query
-      if (response[this.newOutputName] && typeof response[this.newOutputName] === 'object') {
-        const rewrittenResponse = { ...response, ...response[this.newOutputName] };
+      if (
+        pathResponse[this.newOutputName] &&
+        typeof pathResponse[this.newOutputName] === 'object'
+      ) {
+        const rewrittenResponse = { ...pathResponse, ...pathResponse[this.newOutputName] };
         delete rewrittenResponse[this.newOutputName];
         return rewrittenResponse;
       }
     }
-    return response;
+    return pathResponse;
   }
 }
 

--- a/src/rewriters/Rewriter.ts
+++ b/src/rewriters/Rewriter.ts
@@ -56,8 +56,8 @@ abstract class Rewriter {
     return variables;
   }
 
-  public rewriteResponse(response: any, path: string | number): any {
-    return response[path];
+  public rewriteResponse(response: any, key: string | number): any {
+    return response[key];
   }
 }
 

--- a/src/rewriters/Rewriter.ts
+++ b/src/rewriters/Rewriter.ts
@@ -56,8 +56,8 @@ abstract class Rewriter {
     return variables;
   }
 
-  public rewriteResponse(response: any): any {
-    return response;
+  public rewriteResponse(response: any, path: string | number): any {
+    return response[path];
   }
 }
 

--- a/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
+++ b/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
@@ -48,8 +48,8 @@ class ScalarFieldToObjectFieldRewriter extends Rewriter {
     } as NodeAndVarDefs;
   }
 
-  public rewriteResponse(response: any, path: string) {
-    const pathResponse = super.rewriteResponse(response, path);
+  public rewriteResponse(response: any, key: string | number) {
+    const pathResponse = super.rewriteResponse(response, key);
 
     if (typeof response === 'object') {
       // undo the nesting in the response so it matches the original query

--- a/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
+++ b/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
@@ -48,12 +48,15 @@ class ScalarFieldToObjectFieldRewriter extends Rewriter {
     } as NodeAndVarDefs;
   }
 
-  public rewriteResponse(response: any) {
+  public rewriteResponse(response: any, path: string) {
+    const pathResponse = super.rewriteResponse(response, path);
+
     if (typeof response === 'object') {
       // undo the nesting in the response so it matches the original query
-      return response[this.objectFieldName];
+      return pathResponse[this.objectFieldName];
     }
-    return response;
+
+    return pathResponse;
   }
 }
 

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -16,13 +16,13 @@ describe('ast utils', () => {
           moreThings: [{ type: 'dog' }, { type: 'cat' }, { type: 'lion' }]
         }
       };
-      expect(rewriteResultsAtPath(obj, ['thing1', 'moreThings', 'type'], elm => elm + '!')).toEqual(
-        {
-          thing1: {
-            moreThings: [{ type: 'dog!' }, { type: 'cat!' }, { type: 'lion!' }]
-          }
+      expect(
+        rewriteResultsAtPath(obj, ['thing1', 'moreThings', 'type'], (elm, path) => elm[path] + '!')
+      ).toEqual({
+        thing1: {
+          moreThings: [{ type: 'dog!' }, { type: 'cat!' }, { type: 'lion!' }]
         }
-      );
+      });
     });
 
     it("doesn't include null or undefined results", () => {
@@ -49,20 +49,23 @@ describe('ast utils', () => {
           }
         ]
       };
-      expect(rewriteResultsAtPath(obj, ['things', 'moreThings', 'type'], elm => elm + '!')).toEqual(
-        {
-          things: [
-            {
-              moreThings: [{ type: 'dog!' }, { type: 'cat!' }]
-            },
-            {
-              moreThings: [{ type: 'bear!' }, { type: 'cat!' }]
-            }
-          ]
-        }
-      );
       expect(
-        rewriteResultsAtPath(obj, ['things', 'moreThings'], elm => ({ ...elm, meh: '7' }))
+        rewriteResultsAtPath(obj, ['things', 'moreThings', 'type'], (elm, path) => elm[path] + '!')
+      ).toEqual({
+        things: [
+          {
+            moreThings: [{ type: 'dog!' }, { type: 'cat!' }]
+          },
+          {
+            moreThings: [{ type: 'bear!' }, { type: 'cat!' }]
+          }
+        ]
+      });
+      expect(
+        rewriteResultsAtPath(obj, ['things', 'moreThings'], (elm, path) => ({
+          ...elm[path],
+          meh: '7'
+        }))
       ).toEqual({
         things: [
           {


### PR DESCRIPTION
This changes the implementation of `rewriteResultsAtPath` so that now the parent and path of the element is exposed to `Rewriter`.`rewriteResponse` instead of the element itself. This should allow #14 to modify the response.
