### PR TITLE
feat: allow rewriters to modify parent result

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -271,15 +271,13 @@ export const rewriteResultsAtPath = (
 
   if (path.length === 1) {
     if (Array.isArray(curResults)) {
-      newResults[curPathElm] = curResults.map((_, index) => {
+      return curResults.map((_, index) => {
         const newValue = callback(curResults, index);
         return newValue;
       });
-    } else {
-      newResults[curPathElm] = callback(results, curPathElm);
     }
 
-    return newResults;
+    return callback(results, curPathElm);
   }
 
   const remainingPath = path.slice(1);

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -271,10 +271,12 @@ export const rewriteResultsAtPath = (
 
   if (path.length === 1) {
     if (Array.isArray(curResults)) {
-      return curResults.map((_, index) => {
+      newResults[curPathElm] = curResults.map((_, index) => {
         const newValue = callback(curResults, index);
         return newValue;
       });
+
+      return newResults;
     }
 
     return callback(results, curPathElm);

--- a/src/rewriters/NestFieldOutputsRewriter.ts
+++ b/src/rewriters/NestFieldOutputsRewriter.ts
@@ -66,7 +66,7 @@ class NestFieldOutputsRewriter extends Rewriter {
   }
 
   public rewriteResponse(response: any, key: string | number) {
-    const pathResponse = super.rewriteResponse(response, key);
+    const pathResponse = response[key];
 
     if (typeof pathResponse === 'object') {
       // undo the nesting in the response so it matches the original query
@@ -76,10 +76,11 @@ class NestFieldOutputsRewriter extends Rewriter {
       ) {
         const rewrittenResponse = { ...pathResponse, ...pathResponse[this.newOutputName] };
         delete rewrittenResponse[this.newOutputName];
-        return rewrittenResponse;
+        response[key] = rewrittenResponse;
       }
     }
-    return pathResponse;
+
+    return response;
   }
 }
 

--- a/src/rewriters/NestFieldOutputsRewriter.ts
+++ b/src/rewriters/NestFieldOutputsRewriter.ts
@@ -76,7 +76,11 @@ class NestFieldOutputsRewriter extends Rewriter {
       ) {
         const rewrittenResponse = { ...pathResponse, ...pathResponse[this.newOutputName] };
         delete rewrittenResponse[this.newOutputName];
-        response[key] = rewrittenResponse;
+
+        return {
+          ...response,
+          [key]: rewrittenResponse
+        };
       }
     }
 

--- a/src/rewriters/Rewriter.ts
+++ b/src/rewriters/Rewriter.ts
@@ -57,7 +57,7 @@ abstract class Rewriter {
   }
 
   public rewriteResponse(response: any, key: string | number): any {
-    return response[key];
+    return response;
   }
 }
 

--- a/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
+++ b/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
@@ -53,7 +53,10 @@ class ScalarFieldToObjectFieldRewriter extends Rewriter {
       const pathResponse = response[key];
 
       // undo the nesting in the response so it matches the original query
-      response[key] = pathResponse[this.objectFieldName];
+      return {
+        ...response,
+        [key]: pathResponse[this.objectFieldName]
+      };
     }
 
     return response;

--- a/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
+++ b/src/rewriters/ScalarFieldToObjectFieldRewriter.ts
@@ -49,14 +49,14 @@ class ScalarFieldToObjectFieldRewriter extends Rewriter {
   }
 
   public rewriteResponse(response: any, key: string | number) {
-    const pathResponse = super.rewriteResponse(response, key);
-
     if (typeof response === 'object') {
+      const pathResponse = response[key];
+
       // undo the nesting in the response so it matches the original query
-      return pathResponse[this.objectFieldName];
+      response[key] = pathResponse[this.objectFieldName];
     }
 
-    return pathResponse;
+    return response;
   }
 }
 

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -17,10 +17,10 @@ describe('ast utils', () => {
         }
       };
       expect(
-        rewriteResultsAtPath(obj, ['thing1', 'moreThings', 'type'], (elm, path) => {
-          elm[path] = elm[path] + '!';
-          return elm;
-        })
+        rewriteResultsAtPath(obj, ['thing1', 'moreThings', 'type'], (elm, path) => ({
+          ...elm,
+          [path]: elm[path] + '!'
+        }))
       ).toEqual({
         thing1: {
           moreThings: [{ type: 'dog!' }, { type: 'cat!' }, { type: 'lion!' }]
@@ -53,10 +53,10 @@ describe('ast utils', () => {
         ]
       };
       expect(
-        rewriteResultsAtPath(obj, ['things', 'moreThings', 'type'], (elm, path) => {
-          elm[path] = elm[path] + '!';
-          return elm;
-        })
+        rewriteResultsAtPath(obj, ['things', 'moreThings', 'type'], (elm, path) => ({
+          ...elm,
+          [path]: elm[path] + '!'
+        }))
       ).toEqual({
         things: [
           {

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -17,7 +17,10 @@ describe('ast utils', () => {
         }
       };
       expect(
-        rewriteResultsAtPath(obj, ['thing1', 'moreThings', 'type'], (elm, path) => elm[path] + '!')
+        rewriteResultsAtPath(obj, ['thing1', 'moreThings', 'type'], (elm, path) => {
+          elm[path] = elm[path] + '!';
+          return elm;
+        })
       ).toEqual({
         thing1: {
           moreThings: [{ type: 'dog!' }, { type: 'cat!' }, { type: 'lion!' }]
@@ -50,7 +53,10 @@ describe('ast utils', () => {
         ]
       };
       expect(
-        rewriteResultsAtPath(obj, ['things', 'moreThings', 'type'], (elm, path) => elm[path] + '!')
+        rewriteResultsAtPath(obj, ['things', 'moreThings', 'type'], (elm, path) => {
+          elm[path] = elm[path] + '!';
+          return elm;
+        })
       ).toEqual({
         things: [
           {


### PR DESCRIPTION
This updates the behavior of `Rewriter` so that the parent result is modified and returned instead of expecting the result of the modified key path. This is a follow-up to #20. I have successfully used this to create a rewriter capable of renaming fields.

I pushed this as a breaking change but not sure if this warrants another major release.