### PR TITLE
feat(FieldArgTypeRewriter): retrieve var name by object path

### DIFF
--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1,4 +1,10 @@
-import { ASTNode, DocumentNode, FragmentDefinitionNode, VariableDefinitionNode } from 'graphql';
+import {
+  ASTNode,
+  DocumentNode,
+  FragmentDefinitionNode, Kind,
+  ObjectValueNode, ValueNode,
+  VariableDefinitionNode
+} from 'graphql';
 import { pushToArrayAtKey } from './utils';
 
 const ignoreKeys = new Set(['loc']);
@@ -294,3 +300,24 @@ export const rewriteResultsAtPath = (
 
   return newResults;
 };
+
+export const getByPath = (node: ObjectValueNode, path: ReadonlyArray<string>): ValueNode | undefined => {
+  const [firstSegment, ...theRestOfSegments] = path;
+
+  if (!firstSegment) return undefined;
+
+  const theField = node.fields
+    .find(field => field.name.value === firstSegment);
+
+  if (!theField) return undefined;
+
+  if (theRestOfSegments.length === 0) {
+    return theField.value;
+  }
+
+  if (theField.value.kind === Kind.OBJECT) {
+    return getByPath(theField.value, theRestOfSegments)
+  }
+
+  return undefined;
+}


### PR DESCRIPTION
Hi,

This repo has not been active lately, so I hope this project is still maintained.

I'm facing the problem described in this issue: https://github.com/graphql-query-rewriter/core/issues/26; mainly, I need to change the type of field of an input object.

This is my attempt to achieve the desired behavior.

I concentrated on achieving it with as few changes as possible. That's why I introduced a new optional param  `objectPath?: ReadonlyArray<string>` to `FieldArgTypeRewriter`.

Does it make any sense?

I'm looking forward to hearing from you.